### PR TITLE
GemButler updating the blogdiggity gem to 0.1.0-c86b5a9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,23 @@
 GIT
   remote: git://github.com/integrallis/blogdiggity.git
-  revision: d7f73eb3e517c0ea0bf8872b1b525a02472b0ee1 
+  revision: c86b5a9915a5833b0a809628569003b6d6692f5f
   specs:
     blogdiggity (0.1.0)
-      asciidoctor (~> 0.1.0)
-      bootstrap-sass (~> 2.3)
-      coffee-rails (~> 3.2)
+      activerecord-postgresql-adapter
+      asciidoctor
+      bootstrap-sass (>= 2.3.0)
+      coffee-rails
+      figaro
       font-awesome-sass-rails (~> 3.0, >= 3.0.0.1)
-      github_api (~> 0.8.11)
-      jquery-rails (~> 2.2)
-      omniauth (~> 1.1.3)
-      omniauth-github (~> 1.1.0)
+      github_api
+      jquery-rails
+      omniauth-github
+      pg
       pingr (~> 0.0.3)
-      rails (~> 3.1)
-      sass-rails (~> 3.2)
+      rails (>= 3.2)
+      sass-rails
+      uglifier
+      unicorn
 
 GEM
   remote: https://rubygems.org/
@@ -47,8 +51,9 @@ GEM
     activesupport (3.2.13)
       i18n (= 0.6.1)
       multi_json (~> 1.0)
+    addressable (2.3.7)
     arel (3.0.2)
-    asciidoctor (0.1.1)
+    asciidoctor (1.5.2)
     bootstrap-sass (2.3.1.0)
       sass (~> 3.2)
     builder (3.0.4)
@@ -62,52 +67,58 @@ GEM
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    faraday (0.8.7)
-      multipart-post (~> 1.1)
+    faraday (0.8.9)
+      multipart-post (~> 1.2.0)
+    figaro (1.1.0)
+      thor (~> 0.14)
     font-awesome-sass-rails (3.0.2.2)
       railties (>= 3.1.1)
       sass-rails (>= 3.1.1)
-    github_api (0.8.11)
-      faraday (~> 0.8.1)
-      hashie (~> 1.2.0)
+    github_api (0.10.2)
+      addressable
+      faraday (~> 0.8.7)
+      hashie (>= 1.2)
       multi_json (~> 1.4)
-      nokogiri (~> 1.5.2)
+      nokogiri (~> 1.6.0)
       oauth2
-    hashie (1.2.0)
+    hashie (3.4.0)
     hike (1.2.1)
-    httpauth (0.2.0)
     i18n (0.6.1)
     journey (1.0.4)
     jquery-rails (2.2.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.7.7)
-    jwt (0.1.8)
-      multi_json (>= 1.5)
+    jwt (1.3.0)
     kgio (2.8.0)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.21)
+    mini_portile (0.6.2)
     multi_json (1.7.2)
+    multi_xml (0.5.5)
     multipart-post (1.2.0)
-    nokogiri (1.5.9)
-    oauth2 (0.8.1)
-      faraday (~> 0.8)
-      httpauth (~> 0.1)
-      jwt (~> 0.1.4)
-      multi_json (~> 1.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
       rack (~> 1.2)
-    omniauth (1.1.3)
-      hashie (~> 1.2)
-      rack
-    omniauth-github (1.1.0)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
+    omniauth-github (1.1.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
-    omniauth-oauth2 (1.1.1)
-      oauth2 (~> 0.8.0)
-      omniauth (~> 1.0)
+    omniauth-oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      multi_json (~> 1.3)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     pg (0.15.0)
     pingr (0.0.3)
     polyglot (0.3.3)


### PR DESCRIPTION
blogdiggity has been successfully updated from version 0.1.0-d7f73eb to version 0.1.0-c86b5a9.
