### PR TITLE
GemButler updating the bootstrap-sass gem to 3.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.2)
     asciidoctor (0.1.1)
-    bootstrap-sass (2.3.1.0)
+    bootstrap-sass (2.3.1.3)
       sass (~> 3.2)
     builder (3.0.4)
     coffee-rails (3.2.2)


### PR DESCRIPTION
bootstrap-sass has been successfully updated from version 2.3.1.0 to version 3.3.3.
