### PR TITLE
GemButler updating the coffee-rails gem to 4.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,10 +55,10 @@ GEM
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
-    coffee-script (2.2.0)
+    coffee-script (2.3.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.6.2)
+    coffee-script-source (1.9.1)
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
coffee-rails has been successfully updated from version 3.2.2 to version 4.1.0.
