### PR TITLE
GemButler updating the jquery-rails gem to 4.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     httpauth (0.2.0)
     i18n (0.6.1)
     journey (1.0.4)
-    jquery-rails (2.2.1)
+    jquery-rails (2.3.0)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.7.7)


### PR DESCRIPTION
jquery-rails has been successfully updated from version 2.2.1 to version 4.0.3.
