### PR TITLE
GemButler updating the pg gem to 0.18.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
-    pg (0.15.0)
+    pg (0.18.1)
     pingr (0.0.3)
     polyglot (0.3.3)
     rack (1.4.5)


### PR DESCRIPTION
pg has been successfully updated from version 0.15.0 to version 0.18.1.
