### PR TITLE
GemButler updating the sqlite3 gem to 1.3.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.7)
+    sqlite3 (1.3.10)
     thor (0.18.1)
     tilt (1.3.6)
     treetop (1.4.12)


### PR DESCRIPTION
sqlite3 has been successfully updated from version 1.3.7 to version 1.3.10.
