### PR TITLE
GemButler updating the uglifier gem to 2.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.37)
-    uglifier (1.3.0)
+    uglifier (2.2.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
     unicorn (4.6.2)


### PR DESCRIPTION
uglifier has been successfully updated from version 1.3.0 to version 2.7.1.
