### PR TITLE
GemButler updating the actionpack gem to 4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       nokogiri (~> 1.5.2)
       oauth2
     hashie (1.2.0)
-    hike (1.2.1)
+    hike (1.2.3)
     httpauth (0.2.0)
     i18n (0.6.1)
     journey (1.0.4)
@@ -116,7 +116,7 @@ GEM
       rack (>= 0.4)
     rack-ssl (1.3.3)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (3.2.13)
       actionmailer (= 3.2.13)
@@ -142,7 +142,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    sprockets (2.2.2)
+    sprockets (2.2.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)


### PR DESCRIPTION
actionpack has been successfully updated from version 3.2.13 to version 4.2.0.
