### PR TITLE
GemButler updating the activerecord gem to 4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     activesupport (3.2.13)
       i18n (= 0.6.1)
       multi_json (~> 1.0)
-    arel (3.0.2)
+    arel (3.0.3)
     asciidoctor (0.1.1)
     bootstrap-sass (2.3.1.0)
       sass (~> 3.2)
@@ -153,7 +153,7 @@ GEM
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.37)
+    tzinfo (0.3.43)
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)


### PR DESCRIPTION
activerecord has been successfully updated from version 3.2.13 to version 4.2.0.
